### PR TITLE
CI mit Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: ASP.NET Core CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.0.100-preview8-013656
+    - name: Build with dotnet
+      run: dotnet build --configuration Release


### PR DESCRIPTION
Hab mal ne kleine Config angelegt, die bei jedem push (egal ob PR oder commit) über Github Actions testet obs kompiliert. Tests könnte man dann später ja auch ausführen lassen.

@wubbl0rz Als normaler Nutzer hast du leider nur 2000 GH Actions-Minuten pro Monat. Ich denke nicht dass das Repo allzu viel davon brauchen sollte. Aber du solltest das trotzdem wissen, weils ja dann von deinem Guthaben abgezogen wird.

Edit: Weiß aber leider nicht ob Actions für deinen Account schon aktiviert ist...würde man aber auch nur rausfinden wenn du es mergest :P Wenn wirklich müsstest du [hier](https://github.com/features/actions) Actions aktivieren